### PR TITLE
Update requirements.txt to use whisperx package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyworld==0.3.2
 fastapi==0.112.1
 starlette==0.38.2
 
-git+https://github.com/m-bain/whisperx.git@9e3a9e0e38fcec1304e1784381059a0e2c670be5
+whisperx


### PR DESCRIPTION
Replaced direct GitHub link for whisperx with package name to fix installation problem.